### PR TITLE
Issue 10 non flowing error unhandle rejection stop consume

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -96,7 +96,7 @@ Consumer.prototype.listen = function listen(handler) {
     this.logWarn(error);
   });
 
-  this.consumer.once("ready", () => {
+  this.consumer.on("ready", () => {
     this.consumer.subscribe([topic]);
     this.logDebug(`Consumer ${name} is ready on topic ${topic}`);
 

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -81,7 +81,9 @@ Consumer.prototype.on = function on(event, handler) {
  * Main entry function to start consumer
  */
 Consumer.prototype.listen = function listen(handler) {
-  this.debug("Start consumer with options");
+  const { topic, name, mode } = this.options;
+
+  this.logDebug(`Consumer ${name} start with options ${JSON.stringify(this.options)}`);
 
   this.consumer.connect({ timeout: this.options.connectTimeout }, (err) => {
     if (err) {
@@ -91,13 +93,12 @@ Consumer.prototype.listen = function listen(handler) {
 
   this.consumer.on("event.error", (error) => {
     if (error.stack.includes("Local: Broker transport failure")) throw error;
-    this.warn(error);
+    this.logWarn(error);
   });
 
   this.consumer.once("ready", () => {
-    const { topic, name, mode } = this.options;
     this.consumer.subscribe([topic]);
-    this.debug(`Consumer ${name} is ready on topic ${topic}`);
+    this.logDebug(`Consumer ${name} is ready on topic ${topic}`);
 
     if (mode === "flowing") this.flowingConsume(handler);
     else this.nonFlowingConsume(handler);
@@ -108,8 +109,8 @@ Consumer.prototype.listen = function listen(handler) {
  * Recursive function consume message
  */
 Consumer.prototype.nonFlowingConsume = function nonFlowingConsume(handler) {
-  this.consumer.consume(this.options.numMsgFetchPerTime, async (err, messages) => {
-    if (err) throw err;
+  this.consumer.consume(this.options.numMsgFetchPerTime, async (error, messages) => {
+    if (error) this.logError(error);
 
     if (messages.length) {
       await this.nonFlowingCastMessages(messages, handler);
@@ -136,7 +137,7 @@ Consumer.prototype.nonFlowingCastMessages = async function nonFlowingCastMessage
   const msg = messages.shift();
   await handler(msg);
   this.consumer.commitMessage(msg);
-  this.debug(`Committed topic ${msg.topic} partition ${msg.partition} offset ${msg.offset}`);
+  this.logDebug(`Committed topic ${msg.topic} partition ${msg.partition} offset ${msg.offset}`);
 
   // Adding timer to make this function
   // not blocking the event loop
@@ -176,19 +177,27 @@ Consumer.prototype.flowingCommit = function flowingCommit(message) {
 
   this.flowingCommitQueue[partition][index].done = true;
 
-  this.debug(`Flowing commit queue: topic ${message.topic} partition ${message.partition} offset ${message.offset}`);
+  this.logDebug(`Flowing commit queue: topic ${message.topic} partition ${message.partition} offset ${message.offset}`);
 
   while (this.flowingCommitQueue[partition].length && this.flowingCommitQueue[partition][0].done === true) {
     const msgToCommit = this.flowingCommitQueue[partition].shift().message;
     this.consumer.commitMessage(msgToCommit);
-    this.debug(`Committed topic ${msgToCommit.topic} partition ${msgToCommit.partition} offset ${msgToCommit.offset}`);
+    this.logDebug(`Committed topic ${msgToCommit.topic} partition ${msgToCommit.partition} offset ${msgToCommit.offset}`);
   }
 };
 
 /**
  * Log debug message if logger is set
  */
-Consumer.prototype.debug = function debug(log) {
+Consumer.prototype.logError = function logError(log) {
+  // eslint-disable-next-line no-unused-expressions
+  this.logger && this.logger.error(log);
+};
+
+/**
+ * Log debug message if logger is set
+ */
+Consumer.prototype.logDebug = function logDebug(log) {
   // eslint-disable-next-line no-unused-expressions
   this.logger && this.logger.debug(log);
 };
@@ -196,7 +205,7 @@ Consumer.prototype.debug = function debug(log) {
 /**
  * Log warning message if logger is set
  */
-Consumer.prototype.warn = function warn(log) {
+Consumer.prototype.logWarn = function logWarn(log) {
   // eslint-disable-next-line no-unused-expressions
   this.logger && this.logger.warn(log);
 };

--- a/lib/consumer.test.js
+++ b/lib/consumer.test.js
@@ -374,7 +374,7 @@ test("Should log warning if event.error is not broker transport failure", () => 
 });
 
 describe("Test non-flowing mode", () => {
-  test("Test non-flowing mode consume message", async () => {
+  test("Consume message success and pass messages to handler", async () => {
     const mockMessage = { offset: 1 };
     mockRdKafkaConsumer.consume
       .mockImplementationOnce((num, cb) => {
@@ -400,6 +400,42 @@ describe("Test non-flowing mode", () => {
 
     expect(mockRdKafkaConsumer.consume).toBeCalledTimes(2);
     expect(mockRdKafkaConsumer.subscribe).toBeCalledWith(["topic"]);
+    expect(mockTrackHandler).toBeCalledTimes(4);
+    expect(mockRdKafkaConsumer.commitMessage).toBeCalledTimes(4);
+    expect(mockTrackHandler).toBeCalledWith(mockMessage);
+  });
+
+  test("Consume message with error should log error and continue", async () => {
+    const mockError = new Error("abc");
+    const mockMessage = { offset: 1 };
+    mockRdKafkaConsumer.consume
+      .mockImplementationOnce((num, cb) => {
+        cb(mockError, [mockMessage, mockMessage]);
+      })
+      .mockImplementationOnce((num, cb) => {
+        cb(null, [mockMessage, mockMessage]);
+      });
+
+    const mockLogger = { warn: jest.fn(), debug: jest.fn(), error: jest.fn() };
+    consumer = new Consumer({
+      name: "name",
+      host: "host",
+      groupId: "groupId",
+      topic: "topic",
+      intervalFetchMessage: 500,
+      logger: mockLogger,
+    });
+
+    const mockTrackHandler = jest.fn();
+    consumer.listen(mockTrackHandler);
+    eventEmitter.emit("ready");
+
+    await sleep(800);
+
+    expect(mockRdKafkaConsumer.consume).toBeCalledTimes(2);
+    expect(mockRdKafkaConsumer.subscribe).toBeCalledWith(["topic"]);
+    expect(mockLogger.error).toBeCalledTimes(1);
+    expect(mockLogger.error).toBeCalledWith(mockError);
     expect(mockTrackHandler).toBeCalledTimes(4);
     expect(mockRdKafkaConsumer.commitMessage).toBeCalledTimes(4);
     expect(mockTrackHandler).toBeCalledWith(mockMessage);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@uizaio/node-kafka-client",
-  "version": "v0.0.2",
+  "version": "v0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uizaio/node-kafka-client",
-  "version": "v0.0.4",
+  "version": "v0.0.5",
   "description": "A node-rdkafka wrapper with extended features",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The root cause is throwing error at https://github.com/uizaio/node-kafka-client/compare/master...phunguyen19:issue-10-non-flowing-error-unhandle-rejection-stop-consume?expand=1#diff-197df6990e3c808b6703d446eb88bfd2L112 , it's an async function but our `lib/consumer` doesn't support any API to handle that error.

Base on origin code in `node-rdkafka` at https://github.com/Blizzard/node-rdkafka/blob/master/lib/kafka-consumer.js#L456 , the error can be bypass. So, I updated our code to bypass that error and just logging the error.